### PR TITLE
Improve default templates directory search

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@ Changelog
 ---------
 
 
+0.0.3
+~~~~~
+
+* Improve default templates directory search
+
+
 0.0.2
 ~~~~~
 

--- a/template_to_pdf/__init__.py
+++ b/template_to_pdf/__init__.py
@@ -2,7 +2,7 @@ import glob
 import os.path
 import sys
 
-from jinja2 import Environment, FileSystemLoader, select_autoescape
+from jinja2 import Environment, ChoiceLoader, FileSystemLoader, select_autoescape
 from weasyprint import HTML
 
 
@@ -10,7 +10,7 @@ class PdfRenderer:
     template_filename = None
 
     def __init__(self, templates_path=None):
-        default_templates_path = glob.glob('{}/*/templates/'.format(sys.path[0]))
+        default_templates_path = (glob.glob('{}/*/templates/'.format(path)) for path in sys.path[:2])
 
         if isinstance(templates_path, str):
             templates_path = [templates_path]
@@ -19,7 +19,7 @@ class PdfRenderer:
         templates_path += default_templates_path
 
         self._environment = Environment(
-            loader=FileSystemLoader(templates_path),
+            loader=ChoiceLoader(FileSystemLoader(template_path) for template_path in templates_path),
             autoescape=select_autoescape(['html', 'xml']),
         )
         self.template = self._environment.get_template(self.template_filename)


### PR DESCRIPTION
### What

Search for the templates folder on the first to paths of the `sys.path` and not only the first.

### Why

Sometimes the application may append another folder to the `sys.path` and leave the actual project folder as the second. E.g. when running tests* with `pytest -k` pytest might append the test folder to the path: `['/home/luiz/devel/olist/xunxos-plimor/tests/scripts/runners', '/home/luiz/devel/olist/xunxos-plimor', ...]`. The same might happen when executing a script from a module that isn't the expected project root.

\* More specifically [this](https://github.com/olist/xunxos-plimor/pull/16/files#diff-167b6232dccccdaae9b7941314de4f57R12) test with the command `pytest -k test_generate_plp_with_success`